### PR TITLE
Fix repl not correctly starting on macOS

### DIFF
--- a/prolog/metta_lang/metta_loader.pl
+++ b/prolog/metta_lang/metta_loader.pl
@@ -1864,7 +1864,8 @@ cache_file(Original, Ending, CachedFile) :-
        ' '-'~~~'
     ],
     fr_slashes(Replacements, Original, RelPath),
-    atomic_list_concat([Dir, RelPath, Ending], CachedFile).
+    atomic_list_concat([RelPath, Ending], BufferFile),
+    directory_file_path(Dir, BufferFile, CachedFile).
 
 
 /** clean_cache_files is det.

--- a/prolog/metta_lang/metta_parser.pl
+++ b/prolog/metta_lang/metta_parser.pl
@@ -692,7 +692,7 @@ count_lines_in_file(FileName, LineCount) :-
     process_create(path(wc), ['-l', FileName], [stdout(pipe(Out))]),
     read_line_to_string(Out, Result),  % Read the output from the `wc -l` command
     close(Out),  % Close the stream
-    split_string(Result, " ", "", [LineStr|_]),  % Extract the line count
+    split_string(Result, " ", " ", [LineStr|_]),  % Extract the line count
     number_string(LineCount, LineStr).  % Convert the string to an integer
 
 % Helper predicate to read lines from a stream until EOF, incrementing a counter.


### PR DESCRIPTION
The output of `wc -l`, which `count_lines_in_file/2` uses for non-Win64, sometimes has leading whitespace. Setting `PadChars` for `split_string/4` to space collapses that trailing whitespace to give the expected results.