### PR TITLE
Fix DCG for parsing json-rpc messages

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_json_parser.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_json_parser.pl
@@ -21,15 +21,13 @@ headers([Header|Headers]) -->
     header(Header), "\r\n",
     headers(Headers).
 
-json_chars(0, []) --> [].
-json_chars(N, [C|Cs]) --> [C], { succ(Nn, N) }, json_chars(Nn, Cs).
-
 lsp_metta_request(_{headers: Headers, body: Body}) -->
-    headers(HeadersList),
+    headers(HeadersList), !,
     { list_to_assoc(HeadersList, Headers),
       get_assoc("Content-Length", Headers, LengthS),
-      number_string(Length, LengthS) },
-    json_chars(Length, JsonCodes),
+      number_string(Length, LengthS),
+      length(JsonCodes, Length) },
+    JsonCodes,
     { ground(JsonCodes),
       open_codes_stream(JsonCodes, JsonStream),
       json_read_dict(JsonStream, Body, []) }.


### PR DESCRIPTION
The previous version was much much slower for incomplete messages, which would make reading input while the contents of large files were coming in delayed.

On my machine, this took the time it took for the "initialized" message to complete handling from ~45 seconds to ~300ms