### PR TITLE
Debounce xref updates

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
@@ -67,6 +67,8 @@
 
 :- include(lsp_metta_include).
 
+:- use_module(lsp_server_metta, [debug_lsp/3]).
+
 :- use_module(lsp_metta_outline, [line_col/2]).
 
 %:- module(lsp_metta_workspace, [

--- a/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
@@ -257,7 +257,8 @@ xref_submit_and_wait(File) :-
     xref_enqueue_file(File),
     xref_wait_for_file(File).
 
-disable_thread_system.
+% enabled threads.
+disable_thread_system :- fail.
 
 % Send an interrupt to the worker thread
 xref_interrupt_worker(_File) :- disable_thread_system, !.

--- a/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
@@ -264,6 +264,7 @@ xref_interrupt_worker(_File) :- disable_thread_system, !.
 xref_interrupt_worker(File) :-
     ignore((xref_update_file_state(File, processing),
             xref_thread_control(ThreadID),
+            thread_property(ThreadID, status(running)),
             thread_signal(ThreadID, throw(interrupted)))).
 
 % Wait for a specific file to be processed completely

--- a/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_workspace.pl
@@ -10,7 +10,6 @@
                                  succl/2,
                                  xref_maybe/2,
                                  xref_metta_source/1,
-                                 xref_metta_source/1,
                                  xref_reload_source/1,
                                  xref_source_expired/1,
                                  maybe_doc_path/2

--- a/libraries/lsp_server_metta/prolog/lsp_prolog_changes.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_prolog_changes.pl
@@ -1,6 +1,4 @@
-:- module(lsp_changes, [handle_doc_changes/2,
-                        doc_text_fallback/2,
-                        doc_text/2]).
+:- module(lsp_changes, [handle_doc_changes/2]).
 /** <module> LSP changes
 
 Module for tracking edits to the source, in order to be able to act on
@@ -10,9 +8,8 @@ the code as it is in the editor buffer, before saving.
 */
 
 :- use_module(library(readutil), [read_file_to_codes/3]).
-:- use_module(lsp_metta_workspace, [xref_maybe/2]).
+:- use_module(lsp_metta_workspace, [xref_maybe/2, source_file_text/2]).
 
-:- dynamic doc_text/2.
 :- dynamic lsp_state:full_text_next/2.
 
 %! handle_doc_changes(+File:atom, +Changes:list) is det.
@@ -29,30 +26,18 @@ handle_doc_change(Path, Change) :-
       rangeLength: ReplaceLen, text: Text} :< Change,
     !,
     atom_codes(Text, ChangeCodes),
-    doc_text_fallback(Path, OrigCodes),
+    source_file_text(Path, OrigString),
+    string_codes(OrigString, OrigCodes),
     replace_codes(OrigCodes, StartLine, StartChar, ReplaceLen, ChangeCodes,
                   NewText),
     transaction(( retractall(lsp_state:full_text_next(Path, _)),
                   assertz(lsp_state:full_text_next(Path, NewText))
-                )),
-    % TODO put the retractall/assertz in a transaction?
-    retractall(doc_text(Path, _)),
-    assertz(doc_text(Path, NewText)).
+                )).
 handle_doc_change(Path, Change) :-
-    retractall(doc_text(Path, _)),
-    atom_codes(Change.text, TextCodes),
-    assertz(doc_text(Path, TextCodes)).
-
-%! doc_text_fallback(+Path:atom, -Text:text) is det.
-%
-%  Get the contents of the file at =Path=, either with the edits we've
-%  been tracking in memory, or from the file on disc if no edits have
-%  occured.
-doc_text_fallback(Path, Text) :-
-    doc_text(Path, Text), !.
-doc_text_fallback(Path, Text) :-
-    read_file_to_codes(Path, Text, []),
-    assertz(doc_text(Path, Text)).
+    _{text: Text} :< Change,
+    transaction(( retractall(lsp_state:full_text_next(Path, _)),
+                  assertz(lsp_state:full_text_next(Path, Text))
+                )).
 
 %! replace_codes(Text, StartLine, StartChar, ReplaceLen, ReplaceText, -NewText) is det.
 replace_codes(Text, StartLine, StartChar, ReplaceLen, ReplaceText, NewText) :-

--- a/libraries/lsp_server_metta/prolog/lsp_prolog_colours.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_prolog_colours.pl
@@ -19,7 +19,6 @@ Module with predicates for colourizing Prolog code, via library(prolog_colour).
 :- use_module(library(prolog_source), [read_source_term_at_location/3]).
 :- use_module(library(yall)).
 
-:- use_module(lsp_prolog_changes, [doc_text/2]).
 :- use_module(lsp_prolog_utils, [seek_to_line/2,
                           linechar_offset/3]).
 

--- a/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
@@ -933,9 +933,12 @@ handle_msg("textDocument/didChange", Msg, false) :-
 
 % Handle document save notifications
 handle_msg("textDocument/didSave", Msg, Resp) :-
-    _{params: Params} :< Msg,
-    xref_source_expired(Params.textDocument.uri),
-    check_errors_resp(Params.textDocument.uri, Resp).
+    _{params: _{textDocument: TextDoc}} :< Msg,
+    _{uri: Uri} :< TextDoc,
+    doc_path(Uri, Path),
+    read_file_to_string(Path, String, [encoding(utf8)]),
+    xref_maybe(Path, String),
+    check_errors_resp(Uri, Resp).
 
 % Handle document close notifications
 handle_msg("textDocument/didClose", Msg, false) :-

--- a/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
@@ -927,9 +927,15 @@ handle_msg("textDocument/didChange", Msg, false) :-
                 contentChanges: Changes}} :< Msg,
     _{uri: Uri} :< TextDoc,
     doc_path(Uri, Path),
+    % this calculates the new text in the file from changes
+    % asserts doc_text/2 (not used anywhere?); changed to also assert lsp_state:full_text_next/2
     handle_doc_changes(Path, Changes),
-    source_file_text(Path, DocFullText), % Derive from lsp_metta_changes:doc_text_d4/2
-    xref_maybe(Path, DocFullText). % Check if changed and enqueue the reindexing
+    % "manually" calling xref_source_expired/1 and xref_metta_source/1
+    % instead of xref_maybe/1 because that checks
+    % lsp_state:full_text_next/2 to verify if updates are needed,
+    % handle_doc_changes has already made asserted the latest state
+    xref_source_expired(Path),
+    xref_metta_source(Path).
 
 % Handle document save notifications
 handle_msg("textDocument/didSave", Msg, Resp) :-


### PR DESCRIPTION
This refactors some of the logic around updating the xref state for the file while editing, restoring the use of a worker thread, and debounces to not update more than once every five seconds, rather than dropping updates for twenty seconds after edits.