### PR TITLE
Fix path passed to do_metta/5 for load_metta code action

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_metta_code_actions.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_code_actions.pl
@@ -298,8 +298,11 @@ load_metta_code(For, Uri, Code, Result) :-
 load_metta_code(For, Path, Code, Result) :-
     catch_with_backtrace((
         ignore(current_self(Self)),
-        wots(Out, ignore(do_metta(file(lsp(Path)), For, Self, Code, _LastAnswer))),
-        sformat(Result, "; ~w", [Out])
+        wots(Out, ignore(do_metta(file(Path), For, Self, Code, LastAnswer))),
+        ( Out == ""
+        -> sformat(Result, "~w", [LastAnswer])
+        ;  sformat(Result, "~w ; ~w", [LastAnswer, Out])
+        )
     ), Error, (
         sformat(Result, "~w ; Error: ~q", [Code, Error])
     )), !.


### PR DESCRIPTION
This makes the "evaluate metta" code action actually show the value of the evaluated form.

Wrapping the path in `lsp(...)` seems to result in no output. Digging in to `metta_repl.pl`, I see `u_do_metta_exec000` checks to see if the exec is coming from the LSP, but just seems to execute the input anyway, albeit in a way that seems not to do what I want.