### PR TITLE
Allow not redirecting output for metta user io

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_metta_code_actions.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_code_actions.pl
@@ -100,6 +100,8 @@ lsp_hooks:handle_msg_hook(Method, Msg, Result) :-
 :- use_module(library(http/http_json)).
 :- use_module(library(readutil)).
 
+:- use_module(library(streams), [ with_output_to/3 ]).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Handle the textDocument/codeAction Request
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -298,7 +300,9 @@ load_metta_code(For, Uri, Code, Result) :-
 load_metta_code(For, Path, Code, Result) :-
     catch_with_backtrace((
         ignore(current_self(Self)),
-        wots(Out, ignore(do_metta(file(Path), For, Self, Code, LastAnswer))),
+        wots(Out,
+             locally(nb_setval('$dont_redirect_output', true),
+                     ignore(do_metta(file(Path), For, Self, Code, LastAnswer)))),
         ( Out == ""
         -> sformat(Result, "~w", [LastAnswer])
         ;  sformat(Result, "~w ; ~w", [LastAnswer, Out])

--- a/prolog/metta_lang/metta_interp.pl
+++ b/prolog/metta_lang/metta_interp.pl
@@ -1787,6 +1787,9 @@ user_io(G) :-
 %   @arg Goal The Prolog goal to execute with appropriate output redirection.
 %
 user_io_0(G) :-
+    nb_current('$dont_redirect_output', true), !,
+    call(G).
+user_io_0(G) :-
     % If in MettaLog runtime mode, output to the error stream.
     current_prolog_flag(mettalog_rt, true), !,
     original_user_error(Out),


### PR DESCRIPTION
Otherwise when trying to capture the output when evaluating metta code (so the LSP can present it to the user), user_io_0/1 in metta_interp.pl uses with_output_to/2 to force output to go to the original stdout/stderr, defeating the attempt of wots/2 to capture the output.