### PR TITLE
Remove misleading comment

### DIFF
--- a/prolog/metta_lang/metta_interp.pl
+++ b/prolog/metta_lang/metta_interp.pl
@@ -7024,15 +7024,7 @@ qsave_program(Name) :-
 :- ensure_loaded(library(flybase_main)).
 :- ensure_loaded(metta_server).
 
-%
-%   Specifies an initialization goal to be executed when the program is loaded.
-%   This directive performs two actions:
-%   1. `update_changed_files`: Checks and updates any files that have been modified
-%      since the last program run, ensuring the system is synchronized.
-%   2. `after_load /**/`: Restores the system to a prepared state, likely reinitializing any
-%      essential components.
-%
-:- initialization(update_changed_files,after_load /**/).
+:- initialization(update_changed_files).
 
 %!  nts is det.
 %


### PR DESCRIPTION
ChatGPT? This only does one thing when the file is loaded, which is call `update_changed_files/0`. The `after_load` bit is specifying when to run that and is the same as just calling `initialization/1`, so do that instead.