### PR TITLE
More LSP formatter improvements

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
@@ -213,10 +213,19 @@ emit_lines(To, [Line|Lines]) :-
     emit_lines(To, Lines).
 emit_lines(_, []).
 
-lines_to_strings([Line|Lines], [FormattedLine|FormattedLines]) :-
+lines_to_strings_([Line|Lines], [FormattedLine|FormattedLines]) :-
     with_output_to(string(FormattedLine), emit_line(current_output, Line)),
     lines_to_strings(Lines, FormattedLines).
-lines_to_strings([], []).
+lines_to_strings_([], []).
+
+lines_to_strings(InLines, OutLines) :-
+    lines_to_strings_(InLines, OutLines0),
+    % seemingly redundant, but because strings can contain embedded
+    % newlines, the "lines" of OutLines0 may actually be more than one
+    % line, which then causes create_edit_list/3 to generate spurious
+    % edits
+    atomics_to_string(OutLines0, "\n", OutLines1),
+    split_string(OutLines1, "\n", "", OutLines).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Create a List of Edits from the Original and Formatted Lines

--- a/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
@@ -127,8 +127,8 @@ normalize_whitespaces([white(_), close|Rest], [close|Rest1]) :- !,
     normalize_whitespaces(Rest, Rest1).
 % Is this too aggressive?
 normalize_whitespaces([atom(A), white(_), atom(B)|Rest], [atom(A), white(1), atom(B)|Rest1]) :-
-    normalize_whitespaces(Rest, Rest1).
-normalize_whitespaces([X|Rest0], [X|Rest1]) :-
+    !, normalize_whitespaces(Rest, Rest1).
+normalize_whitespaces([X|Rest0], [X|Rest1]) :- !,
     normalize_whitespaces(Rest0, Rest1).
 normalize_whitespaces([], []).
 
@@ -194,15 +194,15 @@ lines_to_strings([], []).
 create_edit_list(Orig, Formatted, Edits) :-
     create_edit_list(0, Orig, Formatted, Edits).
 
-create_edit_list(_, [], [], []).
-create_edit_list(LineNum, [Line|Lines], [], [Edit|Edits]) :-
+create_edit_list(_, [], [], []) :- !.
+create_edit_list(LineNum, [Line|Lines], [], [Edit|Edits]) :- !,
     string_length(Line, LenLen),
     Edit = _{range: _{start: _{line: LineNum, character: 0},
                       end: _{line: LineNum, character: LenLen}},
             newText: ""},
     succ(LineNum, LineNum1),
     create_edit_list(LineNum1, Lines, [], Edits).
-create_edit_list(LineNum, [], [NewLine|NewLines], [Edit|Edits]) :-
+create_edit_list(LineNum, [], [NewLine|NewLines], [Edit|Edits]) :- !,
     string_length(NewLine, LenLen),
     Edit = _{range: _{start: _{line: LineNum, character: 0},
                       end: _{line: LineNum, character: LenLen}},

--- a/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
@@ -127,7 +127,7 @@ normalize_whitespaces([open, white(_), X|Rest], [open, X|Rest1]) :-
     normalize_whitespaces(Rest, Rest1).
 normalize_whitespaces([white(_), close|Rest], [close|Rest1]) :- !,
     normalize_whitespaces(Rest, Rest1).
-% Is this too aggressive?
+% Is this too aggressive? Only one space between atoms in parentheses?
 normalize_whitespaces([atom(A), white(_), atom(B)|Rest], [atom(A), white(1), atom(B)|Rest1]) :-
     !, normalize_whitespaces(Rest, Rest1).
 normalize_whitespaces([X|Rest0], [X|Rest1]) :- !,

--- a/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
@@ -249,7 +249,7 @@ create_edit_list(LineNum, [], [NewLine|NewLines], [Edit|Edits]) :- !,
             newText: NewLine},
     succ(LineNum, LineNum1),
     create_edit_list(LineNum1, [], NewLines, Edits).
-create_edit_list(LineNum, [OrigLine | OrigRest], [FormattedLine | FormattedRest], Edits) :-
+create_edit_list(LineNum, [OrigLine|OrigRest], [FormattedLine|FormattedRest], Edits) :-
     (   OrigLine \= FormattedLine  % Only create an edit if the line has changed
     -> string_length(OrigLine, LineLen), %TODO: what should this be?
        Edit = _{

--- a/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_formatter.pl
@@ -225,13 +225,14 @@ create_edit_list(Orig, Formatted, Edits) :-
     create_edit_list(0, Orig, Formatted, Edits).
 
 create_edit_list(_, [], [], []) :- !.
-create_edit_list(LineNum, [Line|Lines], [], [Edit|Edits]) :- !,
-    string_length(Line, LenLen),
+create_edit_list(LineNum, [_Line|Lines], [], [Edit]) :- !,
+    length(Lines, NLines),
+    EndLine is LineNum + NLines,
+    last(Lines, LastLine),
+    string_length(LastLine, LastLineLen),
     Edit = _{range: _{start: _{line: LineNum, character: 0},
-                      end: _{line: LineNum, character: LenLen}},
-            newText: ""},
-    succ(LineNum, LineNum1),
-    create_edit_list(LineNum1, Lines, [], Edits).
+                      end: _{line: EndLine, character: LastLineLen}},
+            newText: ""}.
 create_edit_list(LineNum, [], [NewLine|NewLines], [Edit|Edits]) :- !,
     string_length(NewLine, LenLen),
     Edit = _{range: _{start: _{line: LineNum, character: 0},

--- a/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_server_metta.pl
@@ -940,7 +940,8 @@ handle_msg("textDocument/didChange", Msg, false) :-
 
 % Handle document save notifications
 handle_msg("textDocument/didSave", Msg, Resp) :-
-    _{params: _{textDocument: TextDoc}} :< Msg,
+    _{params: Params} :< Msg,
+    _{textDocument: TextDoc} :< Params,
     _{uri: Uri} :< TextDoc,
     doc_path(Uri, Path),
     read_file_to_string(Path, String, [encoding(utf8)]),


### PR DESCRIPTION
The main thing this adds is special-casing `let*` to align the variables. There are some issues with it still, but it will hopefully do for now.

Also fixes some issues with extra newlines and spurious edits sent when no changes are needed.