### PR TITLE
Fix debug flag setting for with_no_debug/1

### DIFF
--- a/prolog/metta_lang/metta_debug.pl
+++ b/prolog/metta_lang/metta_debug.pl
@@ -672,7 +672,7 @@ with_no_debug(Goal) :-
     % Otherwise, call the goal while modifying several debugging and execution options.
     with_option(nodebug, true,
         with_option(time, false,
-            with_option(debug, silent,
+            with_option(debug, false,
                 with_option(e, silent,
                     with_option(eval, true,
                         with_option(exec, noskip, call(Goal))))))).


### PR DESCRIPTION
The built-in prolog flag `debug` is of type `bool`, so setting it to `silent` causes an error when create_prolog_flag is called. That error doesn't seem to appear always, but when running in another thread, I can see the error getting printed out. e.g. running the below shows the error in the top-level.

```prolog
thread_create((
   catch(
    create_prolog_flag(debug, silent,
         [keep(false), access(read_write), type(term)]),
       E,
       format(user_error, "ERR SETTING ~q~n", [E])),
   set_prolog_flag(debug, silent) ), _).
```

This causes a problem in the LSP hover, as occasionally the error output gets interleaved with the displayed content