### PR TITLE
Lsp hover improvements

### DIFF
--- a/libraries/lsp_server_metta/prolog/lsp_metta_hover.pl
+++ b/libraries/lsp_server_metta/prolog/lsp_metta_hover.pl
@@ -221,6 +221,8 @@ term_info_string_resolved(Path, Loc, Term, Arity, Str):-
     string(S0),
     trim_white_lines(S0, S),
     S \= "",  % Ensure that the string is not empty.
+    format(string(NoSuchDoc), "***\nAtom ~w: %Undefined% No documentation\n***", [Term]),
+    S \= NoSuchDoc,
     string_length(S, Len),
     Len > 1, % Ensure the string has a minimum length.
     format(string(Str), "~w", [S]).


### PR DESCRIPTION
A variety of improvements for the LSP hover documentation.

This wants #20 to be merged as well, to prevent errors strings from being interspersed with the hover display.